### PR TITLE
rename responsiveVarContext to match the var names it changes

### DIFF
--- a/scss/utils/helpers/_responsiveVarContext.scss
+++ b/scss/utils/helpers/_responsiveVarContext.scss
@@ -80,7 +80,7 @@ $responsiveVarMap--base: (
 ///      }
 /// 	}
 
-/// configures scale factor value for `$dynamicMedia-{sizeName}` at each breakpoint
+/// configures scale factor value for `$scalingMedia-{sizeName}` at each breakpoint
 ///
 /// @prop {Value(px)} responsiveScaleMap.small [1]
 /// @prop {Value(px)} responsiveScaleMap.medium [1.125]
@@ -91,65 +91,65 @@ $responsiveScaleMap: (
 	large:	1.25
 );
 
-/// Creates a Sass context in which the `$dynamicMedia-{sizeName}` variables
-/// are rendered with different values for each `breakpoint` in `$responsiveVarMap--media`.
+/// Creates a Sass context in which the `$scalingMedia-{sizeName}` variables
+/// are rendered with different values for each `breakpoint` in `$responsiveScaleMap`.
 ///
 /// <div style="padding: 8px; background: rgba(255, 229, 51, 0.6); margin: 8px 0 16px 0;">
 /// To avoid generating large chunks of CSS multiple times, this mixin
 /// should only surround properties with responsive vars (see example below)
 /// </div>
 ///
-/// @see $responsiveVarMap--media
-/// @content [Renders CSS with media queries to set value of `$dynamicMedia-m` for given breakpoints in `$responsiveScaleMap`]
+/// @see $responsiveVarMap--scalingMedia
+/// @content [Renders CSS with media queries to set value of `$scalingMedia-m` for given breakpoints in `$responsiveScaleMap`]
 ///
 /// @example scss - setting padding that scales at breakpoints
 /// 	.someCoolImage {
 /// 		background: pink;
 /// 		height: auto;
-/// 		@include responsiveVarContext--media() {
-/// 			width: $dynamicMedia-m; /* this property will be generated with a different value for each breakpoint */
+/// 		@include responsiveVarContext--scalingMedia() {
+/// 			width: $scalingMedia-m; /* this property will be generated with a different value for each breakpoint */
 ///      }
 /// 	}
-@mixin responsiveVarContext--media() {
+@mixin responsiveVarContext--scalingMedia() {
 
 	@each $breakpoint, $scaleVal in $responsiveScaleMap {
 		// until @content accepts arguments, we have to use a temporary global variable
 		// https://github.com/sass/sass/issues/871
 		// http://stackoverflow.com/questions/29596968/passing-arguments-from-a-mixin-to-a-content-block
-		$dynamicMedia-xs: null !default;
-		$oldDynamicMedia-xs: $dynamicMedia-xs;
-		$dynamicMedia-xs: floor(map-get($media-map, xs) * $scaleVal) !global;
+		$scalingMedia-xs: null !default;
+		$oldScalingMedia-xs: $scalingMedia-xs;
+		$scalingMedia-xs: floor(map-get($media-map, xs) * $scaleVal) !global;
 
-		$dynamicMedia-s: null !default;
-		$oldDynamicMedia-s: $dynamicMedia-s;
-		$dynamicMedia-s: floor(map-get($media-map, s) * $scaleVal) !global;
+		$scalingMedia-s: null !default;
+		$oldScalingMedia-s: $scalingMedia-s;
+		$scalingMedia-s: floor(map-get($media-map, s) * $scaleVal) !global;
 
-		$dynamicMedia-m: null !default;
-		$oldDynamicMedia-m: $dynamicMedia-m;
-		$dynamicMedia-m: floor(map-get($media-map, m) * $scaleVal) !global;
+		$scalingMedia-m: null !default;
+		$oldScalingMedia-m: $scalingMedia-m;
+		$scalingMedia-m: floor(map-get($media-map, m) * $scaleVal) !global;
 
-		$dynamicMedia-l: null !default;
-		$oldDynamicMedia-l: $dynamicMedia-l;
-		$dynamicMedia-l: floor(map-get($media-map, l) * $scaleVal) !global;
+		$scalingMedia-l: null !default;
+		$oldScalingMedia-l: $scalingMedia-l;
+		$scalingMedia-l: floor(map-get($media-map, l) * $scaleVal) !global;
 
-		$dynamicMedia-xl: null !default;
-		$oldDynamicMedia-xl: $dynamicMedia-xl;
-		$dynamicMedia-xl: floor(map-get($media-map, xl) * $scaleVal) !global;
+		$scalingMedia-xl: null !default;
+		$oldScalingMedia-xl: $scalingMedia-xl;
+		$scalingMedia-xl: floor(map-get($media-map, xl) * $scaleVal) !global;
 
-		$dynamicMedia-xxl: null !default;
-		$oldDynamicMedia-xxl: $dynamicMedia-xxl;
-		$dynamicMedia-xxl: floor(map-get($media-map, xxl) * $scaleVal) !global;
+		$scalingMedia-xxl: null !default;
+		$oldScalingMedia-xxl: $scalingMedia-xxl;
+		$scalingMedia-xxl: floor(map-get($media-map, xxl) * $scaleVal) !global;
 
 		@include _atMediaUpForVarContext($breakpoint) {
 			@content
 		}
 
-		$dynamicMedia-xs: $oldDynamicMedia-xs !global;
-		$dynamicMedia-s: $oldDynamicMedia-s !global;
-		$dynamicMedia-m: $oldDynamicMedia-m !global;
-		$dynamicMedia-l: $oldDynamicMedia-l !global;
-		$dynamicMedia-xl: $oldDynamicMedia-xl !global;
-		$dynamicMedia-xxl: $oldDynamicMedia-xxl !global;
+		$scalingMedia-xs: $oldScalingMedia-xs !global;
+		$scalingMedia-s: $oldScalingMedia-s !global;
+		$scalingMedia-m: $oldScalingMedia-m !global;
+		$scalingMedia-l: $oldScalingMedia-l !global;
+		$scalingMedia-xl: $oldScalingMedia-xl !global;
+		$scalingMedia-xxl: $oldScalingMedia-xxl !global;
 
 	}
 


### PR DESCRIPTION
I've changed the name of the mixin and the vars for clarity.