### PR TITLE
add safari checkbox height fix

### DIFF
--- a/scss/reset/_forms.scss
+++ b/scss/reset/_forms.scss
@@ -174,6 +174,11 @@ input elements.
 	}
 }
 
+// Safari height fix
+input[type=checkbox] {
+	height: auto;
+}
+
 
 /*doc
 ---


### PR DESCRIPTION
Fixes https://meetup.atlassian.net/browse/SDS-290

An `auto` `height` helps safari align checkboxes correctly.

**Before:**
![before](https://cloud.githubusercontent.com/assets/231252/26079390/a33feb10-3990-11e7-9dd9-6b5706140c47.png)


**After:**
![after](https://cloud.githubusercontent.com/assets/231252/26079396/a603bd0e-3990-11e7-9da5-589da7828177.png)
