### PR TITLE
Made` %text--link` styling available to buttons

### DIFF
--- a/scss/reset/_bodyText.scss
+++ b/scss/reset/_bodyText.scss
@@ -327,18 +327,20 @@ You can always force an anchor to apply a
 linky blue color by applying the `.link` class.
 
 ```html_example
-<p>Let's force this <a class="link" href="#">link</a> to be blue</p>
+<p>Let's force this <a class="link" href="#">link</a> to be red-underlined.</p>
 ```
 */
-a {
+a, button {
 	color: inherit;
 	text-decoration: none;
-	&.link,
-	.runningText & {
+	&.link {
 		@extend %text--link;
 	}
 }
 
+.runningText a {
+	@extend %text--link;
+}
 
 /*doc
 ---


### PR DESCRIPTION
Needed for things like the "read more" button after the truncated descriptions on event home