### PR TITLE
Increased line-height for runningText

### DIFF
--- a/scss/reset/_bodyText.scss
+++ b/scss/reset/_bodyText.scss
@@ -316,13 +316,18 @@ event descriptions).
 </div>
 ```
 */
-.runningText p {
-	@extend %wrapNice;
-	margin-bottom: $space;
-	max-width: 40em;
-	&:last-child {
-		margin-bottom: 0;
+.runningText {
+	line-height: $line-height-runningText;
+
+	p {
+		@extend %wrapNice;
+		margin-bottom: $space;
+		max-width: 40em;
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
+
 }
 
 

--- a/scss/utils/vars/_type.scss
+++ b/scss/utils/vars/_type.scss
@@ -46,3 +46,5 @@ $line-height-largeText : 1.1;
 $line-height           : 1.45;
 /// @type String
 $line-height-smallText : 1.6;
+/// @type String
+$line-height-runningText : 1.8;


### PR DESCRIPTION
Newer designs have been using a bigger line-height for large blocks of text. This makes it the default.