### PR TITLE
Update default link styles

### DIFF
--- a/scss/utils/helpers/_type.scss
+++ b/scss/utils/helpers/_type.scss
@@ -130,8 +130,7 @@
 
 /// Links placeholder
 %text--link {
-	@include color-all($C_textPrimary);
-	border-bottom: 1px solid $C_red;
+	@include color-all($C_accent);
 	text-decoration: none;
 
 	&:link{
@@ -141,13 +140,11 @@
 	&:hover,
 	&:focus,
 	&:active {
-		border-bottom: 1px solid transparent;
-		color: $C_red;
-		text-decoration: none;
+		text-decoration: underline;
 	}
 
 	.button {
-		border-bottom: 1px solid transparent;
+		text-decoration: none;
 	}
 
 	.inverted & {

--- a/scss/utils/vars/_color.scss
+++ b/scss/utils/vars/_color.scss
@@ -17,3 +17,4 @@ $brightness_threshold: 160;
 /// @see {function} getPrimaryTextColor
 $C_contrastDarkBG: #fff;
 $C_contrastLightBG: #000;
+$C_accent: $C_blue;


### PR DESCRIPTION
We're now using `$C_blue` as an accent color (instead of `$C_red` everywhere all of the time). As a part of this work, the design team wants to go with blue links again.