### PR TITLE
More stable styles for wrapping in `.runningText`

### DIFF
--- a/scss/utils/helpers/_type.scss
+++ b/scss/utils/helpers/_type.scss
@@ -198,4 +198,8 @@
 	@include prefixer(hyphenate-limit-after, 2, webkit moz spec);
 	@include prefixer(hyphenate-limit-before, 3, webkit moz spec);
 	@include prefixer(hyphenate-limit-lines, 2, webkit ms spec);
+	overflow-wrap: break-word;
+	-ms-word-break: break-all; // IE wraps funny with `break-word`
+	word-break: break-word;
+	word-wrap: break-word;
 }


### PR DESCRIPTION
Fixes: https://meetup.atlassian.net/browse/MW-2507

Even with the `runningText` class added to the parent div, Group Home descriptions were not wrapping correctly. This should fix and provide better browser support for text wrapping.

Before:
<img width="643" alt="screen shot 2017-11-07 at 12 30 38 pm" src="https://user-images.githubusercontent.com/2313998/32508545-af4d762c-c3b8-11e7-8077-c72b497ac5df.png">

After:
<img width="647" alt="screen shot 2017-11-07 at 12 31 12 pm" src="https://user-images.githubusercontent.com/2313998/32508553-b2aaf024-c3b8-11e7-88f9-b769372c1dc8.png">
