### PR TITLE
Sds 487/improved font stack

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,7 +82,7 @@ module.exports = function(grunt) {
 					context: {
 						DEBUG: false,
 						'VERSION': '<%= package.version %>',
-						'FONT_URL': '//a248.e.akamai.net/secure.meetupstatic.com/s/fonts/402715706936963211631/graphik.css',
+						'FONT_URL': '//www.meetup.com/mu_static/en-US/graphik.c2ab8a6.css',
 						'GITHUB_URL': '//github.com/meetup/swarm-sasstools',
 						'CSS_PATH': './swarm-sasstools.css',
 						'SQ2_URL': '//meetup.github.io/sassquatch2/bundle/sassquatch.css'

--- a/scss/utils/vars/_type.scss
+++ b/scss/utils/vars/_type.scss
@@ -7,7 +7,7 @@
 
 /// Default font stack
 /// @type String
-$font : "Graphik Meetup", helvetica, arial, sans-serif;
+$font : "Graphik Meetup", -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
 
 /// Mono font stack
 /// @type String


### PR DESCRIPTION
Added better fallbacks for Graphik.

The `-apple-system` and `BlinkMacSystemFont` values are references for Safari and Chrome to the "San Francisco" family. OSX Does not expose the system font as a normal font on disk, so this workaround is necessary.