### PR TITLE
No more hyphens in `.runningText`

### DIFF
--- a/scss/utils/helpers/_type.scss
+++ b/scss/utils/helpers/_type.scss
@@ -193,11 +193,6 @@
 
 /// Nice hyphenation for running text
 %wrapNice {
-	@include hyphens(auto);
-	@include prefixer(hyphenate-limit-chars, 5 3 2, ms);
-	@include prefixer(hyphenate-limit-after, 2, webkit moz spec);
-	@include prefixer(hyphenate-limit-before, 3, webkit moz spec);
-	@include prefixer(hyphenate-limit-lines, 2, webkit ms spec);
 	overflow-wrap: break-word;
 	-ms-word-break: break-all; // IE wraps funny with `break-word`
 	word-break: break-word;


### PR DESCRIPTION
https://meetup.atlassian.net/browse/MW-3010

The design doesn't want to hyphenate large blocks of text anymore.