### PR TITLE
Fix wrapping for IE11

### DIFF
--- a/scss/utils/helpers/_type.scss
+++ b/scss/utils/helpers/_type.scss
@@ -194,7 +194,7 @@
 /// Nice hyphenation for running text
 %wrapNice {
 	overflow-wrap: break-word;
-	-ms-word-break: break-all; // IE wraps funny with `break-word`
+	-ms-word-break: normal; // IE wraps funny with `break-word` and `break-all`
 	word-break: break-word;
 	word-wrap: break-word;
 }


### PR DESCRIPTION
Always wrap the entire word when it doesn't fit on 1 line - even in IE

IE11 was doing this:
![words breaking](https://user-images.githubusercontent.com/2313998/34009334-7ad37622-e0d6-11e7-94dd-9ed4a4b45dbe.png)
