### PR TITLE
Deprecate responsiveVarContext--scalingMedia mixin

### DIFF
--- a/scss/modifierClasses/_matchMediaSize.scss
+++ b/scss/modifierClasses/_matchMediaSize.scss
@@ -21,24 +21,10 @@ Class                         | Description
 
 	@include _modifier('matchMediaSize--height', $sizeName) {
 
-		@include responsiveVarContext--scalingMedia() {
-
-			@if ($sizeName == xs) {
-				min-height: $scalingMedia-xs;
+		@each $mediaKey in map-keys($media-map) {
+			@if ($sizeName == $mediaKey and not ($sizeName == xl) and not ($sizeName == xxl)) {
+				@include responsiveValue(min-height, var(--scalingMedia-#{$mediaKey}), '$media-'#{$mediaKey})
 			}
-
-			@if ($sizeName == s) {
-				min-height: $scalingMedia-s;
-			}
-
-			@if ($sizeName == m) {
-				min-height: $scalingMedia-m;
-			}
-
-			@if ($sizeName == l) {
-				min-height: $scalingMedia-l;
-			}
-
 		}
 
 	}

--- a/scss/modifierClasses/_size.scss
+++ b/scss/modifierClasses/_size.scss
@@ -20,32 +20,10 @@ Class          | Description
 	@include _modifier('media', $sizeName) {
 		height: auto;
 
-		@include responsiveVarContext--scalingMedia() {
-
-			@if ($sizeName == xs) {
-				width: $scalingMedia-xs;
+		@each $mediaKey in map-keys($media-map) {
+			@if ($sizeName == $mediaKey) {
+				@include responsiveValue(width, var(--scalingMedia-#{$mediaKey}), '$media-'#{$mediaKey})
 			}
-
-			@if ($sizeName == s) {
-				width: $scalingMedia-s;
-			}
-
-			@if ($sizeName == m) {
-				width: $scalingMedia-m;
-			}
-
-			@if ($sizeName == l) {
-				width: $scalingMedia-l;
-			}
-
-			@if ($sizeName == xl) {
-				width: $scalingMedia-xl;
-			}
-
-			@if ($sizeName == xxl) {
-				width: $scalingMedia-xxl;
-			}
-
 		}
 
 	}

--- a/scss/reset/_customProperties.scss
+++ b/scss/reset/_customProperties.scss
@@ -1,0 +1,30 @@
+//
+// Default values
+//
+:root {
+	--mediaScale: $mediaScale;
+	@each $mediaKey in map-keys($media-map) {
+		--scalingMedia-#{$mediaKey}: floor(map-get($media-map, #{$mediaKey}) * $mediaScale);
+	}
+}
+
+//
+// Breakpoint values
+//
+
+// mediaScale
+// scalingMedia-{size}
+@each $breakpoint, $responsiveScaleValue in (
+	medium: 1.125,
+	large: 1.25,
+) {
+	@include atMediaUp($breakpoint) {
+		:root {
+			--mediaScale: $responsiveScaleValue;
+
+			@each $mediaKey in map-keys($media-map) {
+				--scalingMedia-#{$mediaKey}: floor(map-get($media-map, #{$mediaKey}) * $responsiveScaleValue);
+			}
+		}
+	}
+}

--- a/scss/reset/all.scss
+++ b/scss/reset/all.scss
@@ -12,6 +12,7 @@
 @import "../utils/all";
 
 // keep this order for cascade
+@import "customProperties";
 @import "tagDefaults";
 @import "tables";
 @import "forms";

--- a/scss/utils/helpers/_responsiveVarContext.scss
+++ b/scss/utils/helpers/_responsiveVarContext.scss
@@ -2,6 +2,21 @@
 /// @group Responsive Variables
 ////
 
+/// Sets a property and a value while accepting
+/// a hard-coded fallback value for browsers that
+/// don't support CSS custom properties.
+/// 
+/// @access private
+/// @content [Style rules]
+@mixin responsiveValue($properties, $cssVar, $fallback) {
+	@each $prop in $properties {
+		@if $fallback { 
+			#{$prop}: $fallback;
+		}
+		#{$prop}: $cssVar;
+	}
+}
+
 /// Assumes `small` or `default` values passed in as
 /// $breakpoint should not be wrapped in an `atMediaUp` media query
 /// @access private

--- a/scss/utils/vars/_scale.scss
+++ b/scss/utils/vars/_scale.scss
@@ -88,6 +88,8 @@ $space-quarter   : $space/4;
 * can be thought of as "media". The following variables
 * set media sizes based on our modular scale:
 */
+/// @type Value(number)
+$mediaScale: 1;
 /// @type Value(px)
 $media-xs : $space;    // 16px
 /// @type Value(px)


### PR DESCRIPTION
I replaced usage of the responsiveVarContext--scalingMedia mixin with custom properties. I didn't add a deprecation warning in the Readme because I think we can pretty quickly follow up remove the code entirely - it just needs to be removed avatar styles in `meetup-web-components`, and comment form styles in `mup-web`