### PR TITLE
Add pages for media sizes and spacing metrics

### DIFF
--- a/docs/examples/mediaSizes.html
+++ b/docs/examples/mediaSizes.html
@@ -5,34 +5,13 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
-	<title>swarm-sasstools <!-- @echo VERSION --> typography spec</title>
+	<title>swarm-sasstools <!-- @echo VERSION --> spacing values</title>
 
 	<!-- font -->
 	<link rel="stylesheet" href="<!-- @echo FONT_URL -->" />
 
 	<!-- CSS to be documented -->
 	<link rel="stylesheet" href="../seldon/<!-- @echo CSS_PATH -->" />
-
-	<style type="text/css">
-		.__doc_card--inverted {
-			background-color: #353e48; /* $C_darkGray as of 08/09/2017 */
-		}
-
-		.__docs_text--primary {
-			color: rgba(46, 62, 72, 1) !important; /* $C_textPrimary as of 08/09/2017 */
-		}
-
-		.inverted .__docs_text--primary {
-			color: rgba(255, 255, 255, 1) !important; /* $C_textPrimaryInverted as of 08/09/2017 */
-		}
-
-		.inverted th.text--error,
-		.inverted td.text--error {
-			color: #ff5b0f; /* $C_attention as of 08/09/2017 */
-		}
-
-	</style>
-
 </head>
 <!--[if IE 8]> <body class="lang_en ieRoot_IE8 ieRoot_lt_IE9 ieRoot_lt_IE10"> <![endif]-->
 <!--[if IE 9]> <body class="lang_en ieRoot_IE9 ieRoot_lt_IE10"> <![endif]-->
@@ -42,85 +21,58 @@
 
 	<div class="section section--hasSeparator border--none">
 
-		<div class="flex flex--column atMedium_flex--row">
-			<div class="flex-item">
-				<div class="chunk">
-					<h4 class="text--bold">Light bg</h4>
-					<div class="card padding--bottom flush--left flush--right">
-						<table class="span--100">
-							<thead>
-									<tr>
-											<th>Name</th>
-											<th>Base color</th>
-											<th>Alpha</th>
-									</tr>
-							</thead>
-							<tbody>
-									<tr>
-										<th class="__docs_text--primary">Primary</th>
-										<td class="__docs_text--primary">#2E3E48</td>
-										<td class="__docs_text--primary">1.0</td>
-									</tr>
-									<tr>
-										<th class="text--secondary">Secondary</th>
-										<td class="text--secondary">#2E3E48</td>
-										<td class="text--secondary">.60</td>
-									</tr>
-									<tr>
-										<th class="text--hint">Hint</th>
-										<td class="text--hint">#2E3E48</td>
-										<td class="text--hint">.35</td>
-									</tr>
-									<tr>
-										<th class="text--error">Error</th>
-										<td class="text--error">#FF5B0F</td>
-										<td class="text--error">1.0</td>
-									</tr>
-							</tbody>
-						</table>
-					</div>
-				</div>
-			</div>
-			<div class="flex-item">
-				<div class="chunk">
-					<h4 class="text--bold">Dark bg</h4>
-					<div class="card padding--bottom flush--left flush--right inverted __doc_card--inverted">
-						<table class="span--100">
-							<thead>
-									<tr>
-											<th>Name</th>
-											<th>Base color</th>
-											<th>Alpha</th>
-									</tr>
-							</thead>
-							<tbody>
-									<tr>
-										<th class="__docs_text--primary">Primary</th>
-										<td class="__docs_text--primary">#FFFFFF</td>
-										<td class="__docs_text--primary">1.0</td>
-									</tr>
-									<tr>
-										<th class="text--secondary">Secondary</th>
-										<td class="text--secondary">#FFFFFF</td>
-										<td class="text--secondary">.70</td>
-									</tr>
-									<tr>
-										<th class="text--hint">Hint</th>
-										<td class="text--hint">#FFFFFF</td>
-										<td class="text--hint">.35</td>
-									</tr>
-									<tr>
-										<th class="text--error">Error</th>
-										<td class="text--error">#FF5B0F</td>
-										<td class="text--error">1.0</td>
-									</tr>
-							</tbody>
-						</table>
-					</div>
-				</div>
-				</div>
+		<div class="chunk">
+			<div class="card padding--bottom flush--left flush--right">
+				<table class="span--100">
+					<thead>
+						<tr>
+							<th>Viewport</th>
+							<th>xxs</th>
+							<th>xs</th>
+							<th>s</th>
+							<th>m</th>
+							<th>l</th>
+							<th>xl</th>
+							<th>xxl</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td class="text--bold">Small</td>
+							<td>12</td>
+							<td>16</td>
+							<td>24</td>
+							<td>36</td>
+							<td>48</td>
+							<td>72</td>
+							<td>120</td>
+						</tr>
+						<tr>
+							<td class="text--bold">Medium</td>
+							<td>13</td>
+							<td>18</td>
+							<td>27</td>
+							<td>40</td>
+							<td>54</td>
+							<td>81</td>
+							<td>135</td>
+						</tr>
+						<tr>
+							<td class="text--bold flush--bottom">Large</td>
+							<td class="flush--bottom">15</td>
+							<td class="flush--bottom">20</td>
+							<td class="flush--bottom">30</td>
+							<td class="flush--bottom">45</td>
+							<td class="flush--bottom">60</td>
+							<td class="flush--bottom">90</td>
+							<td class="flush--bottom">150</td>
+						</tr>
+					</tbody>
+				</table>
 			</div>
 		</div>
+
+	</div>
 
 </div></div>
 

--- a/docs/examples/spacing.html
+++ b/docs/examples/spacing.html
@@ -5,34 +5,13 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
-	<title>swarm-sasstools <!-- @echo VERSION --> typography spec</title>
+	<title>swarm-sasstools <!-- @echo VERSION --> spacing values</title>
 
 	<!-- font -->
 	<link rel="stylesheet" href="<!-- @echo FONT_URL -->" />
 
 	<!-- CSS to be documented -->
 	<link rel="stylesheet" href="../seldon/<!-- @echo CSS_PATH -->" />
-
-	<style type="text/css">
-		.__doc_card--inverted {
-			background-color: #353e48; /* $C_darkGray as of 08/09/2017 */
-		}
-
-		.__docs_text--primary {
-			color: rgba(46, 62, 72, 1) !important; /* $C_textPrimary as of 08/09/2017 */
-		}
-
-		.inverted .__docs_text--primary {
-			color: rgba(255, 255, 255, 1) !important; /* $C_textPrimaryInverted as of 08/09/2017 */
-		}
-
-		.inverted th.text--error,
-		.inverted td.text--error {
-			color: #ff5b0f; /* $C_attention as of 08/09/2017 */
-		}
-
-	</style>
-
 </head>
 <!--[if IE 8]> <body class="lang_en ieRoot_IE8 ieRoot_lt_IE9 ieRoot_lt_IE10"> <![endif]-->
 <!--[if IE 9]> <body class="lang_en ieRoot_IE9 ieRoot_lt_IE10"> <![endif]-->
@@ -42,85 +21,42 @@
 
 	<div class="section section--hasSeparator border--none">
 
-		<div class="flex flex--column atMedium_flex--row">
-			<div class="flex-item">
-				<div class="chunk">
-					<h4 class="text--bold">Light bg</h4>
-					<div class="card padding--bottom flush--left flush--right">
-						<table class="span--100">
-							<thead>
-									<tr>
-											<th>Name</th>
-											<th>Base color</th>
-											<th>Alpha</th>
-									</tr>
-							</thead>
-							<tbody>
-									<tr>
-										<th class="__docs_text--primary">Primary</th>
-										<td class="__docs_text--primary">#2E3E48</td>
-										<td class="__docs_text--primary">1.0</td>
-									</tr>
-									<tr>
-										<th class="text--secondary">Secondary</th>
-										<td class="text--secondary">#2E3E48</td>
-										<td class="text--secondary">.60</td>
-									</tr>
-									<tr>
-										<th class="text--hint">Hint</th>
-										<td class="text--hint">#2E3E48</td>
-										<td class="text--hint">.35</td>
-									</tr>
-									<tr>
-										<th class="text--error">Error</th>
-										<td class="text--error">#FF5B0F</td>
-										<td class="text--error">1.0</td>
-									</tr>
-							</tbody>
-						</table>
-					</div>
-				</div>
-			</div>
-			<div class="flex-item">
-				<div class="chunk">
-					<h4 class="text--bold">Dark bg</h4>
-					<div class="card padding--bottom flush--left flush--right inverted __doc_card--inverted">
-						<table class="span--100">
-							<thead>
-									<tr>
-											<th>Name</th>
-											<th>Base color</th>
-											<th>Alpha</th>
-									</tr>
-							</thead>
-							<tbody>
-									<tr>
-										<th class="__docs_text--primary">Primary</th>
-										<td class="__docs_text--primary">#FFFFFF</td>
-										<td class="__docs_text--primary">1.0</td>
-									</tr>
-									<tr>
-										<th class="text--secondary">Secondary</th>
-										<td class="text--secondary">#FFFFFF</td>
-										<td class="text--secondary">.70</td>
-									</tr>
-									<tr>
-										<th class="text--hint">Hint</th>
-										<td class="text--hint">#FFFFFF</td>
-										<td class="text--hint">.35</td>
-									</tr>
-									<tr>
-										<th class="text--error">Error</th>
-										<td class="text--error">#FF5B0F</td>
-										<td class="text--error">1.0</td>
-									</tr>
-							</tbody>
-						</table>
-					</div>
-				</div>
-				</div>
+		<div class="chunk">
+			<div class="card padding--bottom flush--left flush--right">
+				<table class="span--100">
+					<thead>
+						<tr>
+							<th>Viewport</th>
+							<th>SpaceHalf</th>
+							<th>Space</th>
+							<th>SpaceDouble</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>Small</td>
+							<td>8</td>
+							<td>16</td>
+							<td>32</td>
+						</tr>
+						<tr>
+							<td>Medium</td>
+							<td>9</td>
+							<td>18</td>
+							<td>36</td>
+						</tr>
+						<tr>
+							<td class="flush--bottom">Large</td>
+							<td class="flush--bottom">10</td>
+							<td class="flush--bottom">20</td>
+							<td class="flush--bottom">40</td>
+						</tr>
+					</tbody>
+				</table>
 			</div>
 		</div>
+
+	</div>
 
 </div></div>
 

--- a/docs/examples/typeSpec.html
+++ b/docs/examples/typeSpec.html
@@ -26,7 +26,7 @@
 
 <div class="stripe"><div class="bounds">
 	<!-- DISPLAY -->
-	<div class="section">
+	<div class="section flush--left flush--right">
 		<div class="flex flex--column atMedium_flex--row">
 			<div class="flex-item">
 				<div class="chunk">
@@ -63,7 +63,7 @@
 	</div>
 
 	<!-- PAGE TITLE -->
-	<div class="section">
+	<div class="section flush--left flush--right">
 		<div class="flex flex--column atMedium_flex--row">
 			<div class="flex-item">
 				<div class="chunk">
@@ -100,7 +100,7 @@
 	</div>
 
 	<!-- BIG TEXT -->
-	<div class="section">
+	<div class="section flush--left flush--right">
 		<div class="flex flex--column atMedium_flex--row">
 			<div class="flex-item">
 				<div class="chunk">
@@ -137,7 +137,7 @@
 	</div>
 
 	<!-- SECTION TITLE -->
-	<div class="section">
+	<div class="section flush--left flush--right">
 		<div class="flex flex--column atMedium_flex--row">
 			<div class="flex-item">
 				<div class="chunk">
@@ -174,7 +174,7 @@
 	</div>
 
 	<!-- BODY -->
-	<div class="section">
+	<div class="section flush--left flush--right">
 		<div class="flex flex--column atMedium_flex--row">
 			<div class="flex-item">
 				<div class="chunk">
@@ -211,7 +211,7 @@
 	</div>
 
 	<!-- SMALL -->
-	<div class="section">
+	<div class="section flush--left flush--right">
 		<div class="flex flex--column atMedium_flex--row">
 			<div class="flex-item">
 				<div class="chunk">
@@ -248,11 +248,11 @@
 	</div>
 
 	<!-- TINY -->
-	<div class="section">
+	<div class="section flush--left flush--right">
 		<div class="flex flex--column atMedium_flex--row">
 			<div class="flex-item">
 				<div class="chunk">
-					<p class="text--small">Small text</p>
+					<p class="text--tiny">Tiny text</p>
 				</div>
 			</div>
 			<div class="flex-item">

--- a/docs/examples/typeWeight.html
+++ b/docs/examples/typeWeight.html
@@ -42,7 +42,7 @@
 
 <div class="stripe"><div class="bounds">
 
-	<div class="section section--hasSeparator border--none">
+	<div class="section section--hasSeparator border--none flush--left flush--right">
 
 		<div class="flex flex--column atMedium_flex--row">
 


### PR DESCRIPTION
Currently, [swarm-design-system](https://github.com/meetup/swarm-design-system) is creating tables for media sizes and spacing metrics in Markdown.
Giving them their own pages that get iframed into the docs will open us up to dynamically generating/updating the page content via swarm-constants