### PR TITLE
margin:0 for <button>

### DIFF
--- a/scss/reset/_forms.scss
+++ b/scss/reset/_forms.scss
@@ -106,6 +106,7 @@ textarea {
 button {
 	background: transparent;
 	border-width: 0;
+	margin: 0;
 	padding: 0;
 }
 


### PR DESCRIPTION
Safari adds a 2px top and bottom margin to `<button>`

<img width="448" alt="editseriesmodal_button_alignment" src="https://user-images.githubusercontent.com/2313998/36288789-7f79356e-128a-11e8-9aad-fa17977cd325.png">
