### PR TITLE
rm custom property dist

### DIFF
--- a/scss/reset/all.scss
+++ b/scss/reset/all.scss
@@ -9,7 +9,6 @@
 * - Body text classes
 * - Debug classes
 */
-@import "~swarm-constants/dist/css/customProperties";
 @import "../utils/all";
 
 // keep this order for cascade


### PR DESCRIPTION
**Removes custom property definitions from sasstools reset**

[CONST-13](https://meetup.atlassian.net/browse/CONST-13) explains why:

> Currently, we import a `customProperties` dist to the SST reset. While this works great for modern browsers, postcss is unable to calculate a computed value because the custom property definitions are not in global scope (the SST reset never runs through the postcss-loader).
To fix this, we must...

> 1) create a new dist for scss modules
> 2) make sure we prefix selectors with `:global`, to put custom property definitions into global scope
> 3) assume that consumer apps (or platform renderer) is responsible for importing the custom properties module dist into app code

### tl;dr
PostCSS can't get calculated values for custom properties if we import them here in Sasstools