### PR TITLE
Add explicit depenendices to all `utils/` partials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 3.0.$(CI_BUILD_NUMBER)
+VERSION ?= 3.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/README.md
+++ b/README.md
@@ -68,10 +68,14 @@ Removed `responsiveVarContext--scalingMedia()` mixin in favor of CSS custom prop
 }
 ```
 
-#### v2.X.X
+#### 3.1.X
+All partials in `scss/utils/` now explicitly import their dependencies, making it easier
+to treat a specific utility as a standalone import. This is not a breaking change.
+
+#### 2.X.X
 Form inputs were re-styled. These updates increased padding on inputs considerably, and may cause layouts to shift. This should only be an issue for screens with designs that rely on the inputs being a specific height.
 
-#### v1.7
+#### 1.7.X
 Introduced big visual changes to type and scaling, but no breaking changes.
 - deprecated `%text--display2`, `.text--display2`
 - deprecated `%text--display3`, `.text--display3`

--- a/scss/utils/_all.scss
+++ b/scss/utils/_all.scss
@@ -37,22 +37,14 @@
 @import "functions/color";
 
 //
-// helpers with dependencies
+// helpers
 //
-@import "helpers/pcv-modifier";
-@import "helpers/selector";
 @import "helpers/a11y";
-@import "helpers/i18n";
-@import "helpers/browser";
-@import "helpers/breakpoint";
-@import "helpers/position";
-
-//
-// helpers (depends on above)
-//
 @import "helpers/align";
 @import "helpers/background";
 @import "helpers/border";
+@import "helpers/breakpoint";
+@import "helpers/browser";
 @import "helpers/button";
 @import "helpers/color";
 @import "helpers/customPropertyValue";
@@ -60,8 +52,12 @@
 @import "helpers/flexbox";
 @import "helpers/float";
 @import "helpers/forms";
+@import "helpers/i18n";
 @import "helpers/lists";
+@import "helpers/pcv-modifier";
+@import "helpers/position";
 @import "helpers/type";
+@import "helpers/selector";
 @import "helpers/shadow";
 @import "helpers/shape";
 @import "helpers/width";

--- a/scss/utils/customProperties/_responsive.scss
+++ b/scss/utils/customProperties/_responsive.scss
@@ -1,3 +1,6 @@
+ @import "~swarm-constants/dist/scss/vars";
+ @import "../vars/scale";
+
 //
 // Default values
 //

--- a/scss/utils/functions/_brightness.scss
+++ b/scss/utils/functions/_brightness.scss
@@ -1,3 +1,5 @@
+@import "~swarm-constants/dist/scss/vars";
+
 ////
 /// @group brightness
 ////

--- a/scss/utils/functions/_color.scss
+++ b/scss/utils/functions/_color.scss
@@ -1,3 +1,5 @@
+@import "~swarm-constants/dist/scss/vars";
+
 ////
 /// @group color
 /// @access public

--- a/scss/utils/helpers/_align.scss
+++ b/scss/utils/helpers/_align.scss
@@ -1,3 +1,5 @@
+@import "~bourbon/app/assets/stylesheets/_bourbon.scss";
+
 ////
 /// @group alignment
 ////

--- a/scss/utils/helpers/_border.scss
+++ b/scss/utils/helpers/_border.scss
@@ -1,3 +1,5 @@
+@import "~swarm-constants/dist/scss/vars";
+
 ////
 /// @group border
 ////

--- a/scss/utils/helpers/_breakpoint.scss
+++ b/scss/utils/helpers/_breakpoint.scss
@@ -1,3 +1,5 @@
+@import "~swarm-constants/dist/scss/vars";
+
 ////
 /// @group breakpoint
 ////

--- a/scss/utils/helpers/_browser.scss
+++ b/scss/utils/helpers/_browser.scss
@@ -1,3 +1,5 @@
+@import "../vars/prefix";
+
 ////
 /// @group browser
 ////

--- a/scss/utils/helpers/_button.scss
+++ b/scss/utils/helpers/_button.scss
@@ -1,3 +1,5 @@
+@import "~bourbon/app/assets/stylesheets/_bourbon.scss";
+
 ////
 /// @group button
 ////

--- a/scss/utils/helpers/_flexbox.scss
+++ b/scss/utils/helpers/_flexbox.scss
@@ -1,3 +1,6 @@
+@import "~bourbon/app/assets/stylesheets/_bourbon.scss";
+@import "./browser";
+
 ////
 /// @group flexbox
 ////

--- a/scss/utils/helpers/_forms.scss
+++ b/scss/utils/helpers/_forms.scss
@@ -1,3 +1,6 @@
+@import "~swarm-constants/dist/scss/vars";
+@import "../vars/layout";
+
 ////
 /// @group forms
 ////

--- a/scss/utils/helpers/_i18n.scss
+++ b/scss/utils/helpers/_i18n.scss
@@ -1,3 +1,5 @@
+ @import "../vars/root-class";
+
 ////
 /// @group i18n
 ////

--- a/scss/utils/helpers/_shadow.scss
+++ b/scss/utils/helpers/_shadow.scss
@@ -1,3 +1,5 @@
+@import "~swarm-constants/dist/scss/vars";
+
 ////
 /// @group Shadow
 ////

--- a/scss/utils/helpers/_type.scss
+++ b/scss/utils/helpers/_type.scss
@@ -1,3 +1,9 @@
+@import "~bourbon/app/assets/stylesheets/_bourbon.scss";
+@import "~swarm-constants/dist/scss/vars";
+@import "../vars/type";
+@import "../vars/color";
+@import "./color";
+
 ////
 /// @group Typography
 ////


### PR DESCRIPTION
https://meetup.atlassian.net/browse/SST-15

Makes all partials in `scss/utils/` self-sufficient and individually importable by explicitly declaring dependencies. This makes it easier to import a specific utility into a style module without needed to figure out its dependencies.

Also cleaned up the import order in `_all.scss` where we previously had to import things in a certain order because some helpers depended on others. Now that each util partial declares what it needs, we can deport them in any order now.

The diff between compiled CSS in this branch and compiled CSS in `master` is clean.

## Local testing
If you'd like to test locally, comment out all the lib and `var/` imports in `utils/_all.scss` and build. There will be no errors, as each util imports what it needs directly.

We're leaving the lib and var imports in `all.scss` to prevent breakage in older usage (where importing `utils/_all.scss` is assumed to provide libs). Duplicate imports are not a problem in this case, because they only contain silent Sass.