### PR TITLE
Added sticky position modifiers

### DIFF
--- a/scss/modifierClasses/_sticky.scss
+++ b/scss/modifierClasses/_sticky.scss
@@ -1,3 +1,20 @@
+/*doc
+---
+title: Sticky
+name: stickyMod
+category: Modifier Classes
+---
+Sets the position property of element to `sticky`, and
+uses modifier classes for picking a which side of the
+viewport to stick to
+
+Class                   | Description
+----------------------- | --------------------------------
+`.sticky`               | sets `position` to `sticky`
+`.sticky--top`          | sets `top` to `0`, causing element to "stick" to the top of the viewport
+`.sticky--bottom`       | sets `bottom` to `0`, causing element to "stick" to the bottom of the viewport
+*/
+
 .sticky {
 	position: -webkit-sticky;
 	position: sticky;

--- a/scss/modifierClasses/_sticky.scss
+++ b/scss/modifierClasses/_sticky.scss
@@ -1,0 +1,10 @@
+.sticky {
+	position: -webkit-sticky;
+	position: sticky;
+}
+
+@each $direction in (top, bottom) {
+	@include _modifier(sticky, $direction) {
+		#{$direction}: 0;
+	}
+}

--- a/scss/modifierClasses/all.scss
+++ b/scss/modifierClasses/all.scss
@@ -19,6 +19,7 @@
 @import "row";
 @import "size";
 @import "spacing";
+@import "sticky";
 @import "text";
 @import "thumb";
 @import "visibility";


### PR DESCRIPTION
An alternate way to do this would have been:

**scss/modifierClasses/_position.scss**
```.position--sticky {styles}```

**scss/modifierClasses/_sticky.scss**
```.sticky--top {styles}```

But I don't see us adding any other position modifiers, so this felt better.