### PR TITLE
Added links to swarm-constants

### DIFF
--- a/scss/utils/vars/_layout.scss
+++ b/scss/utils/vars/_layout.scss
@@ -5,37 +5,37 @@
 ////
 
 /// modal default width
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $modal-width: $width-modal;
 
 /// bounds default width
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $bounds: $width-bounds;
 
 /// bounds wide variant width
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $bounds-wide: $width-bounds-wide;
 
 /// small border-radius value
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $smallRadius: $radius-small;
 
 /// default border-radius value
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $defaultRadius: $radius-normal;
 
 /// large border-radius value
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $largeRadius: $radius-large;
 
 /// zindex aliases
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @prop {Number} zindex-map.main [0]
 /// @prop {Number} zindex-map.floating-content [10]
 /// @prop {Number} zindex-map.shade [20]

--- a/scss/utils/vars/_scale.scss
+++ b/scss/utils/vars/_scale.scss
@@ -20,31 +20,31 @@
 * `48px`, moving up the `1:1.5` type scale.
 */
 /// scales from 48px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $block           : $block-1;
 /// scales from 48px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $block-2         : $block-2;
 /// scales from 48px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $block-3         : $block-3;
 /// scales from 48px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $block-4         : $block-4;
 /// scales from 48px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $block-5         : $block-5;
 /// scales from 48px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $block-6         : $block-6;
 /// scales from 48px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $block-7         : $block-7;
 
@@ -53,34 +53,34 @@ $block-7         : $block-7;
 * `16px`, moving up the `1:1.5` type scale.
 */
 /// scales from 16px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $space           : $space-1;
 /// scales from 16px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $space-2         : $space-2;
 /// scales from 16px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $space-3         : $space-3;
 /// scales from 16px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $space-4         : $space-4;
 /// scales from 16px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $space-5         : $space-5;
 /// scales from 16px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $space-6         : $space-6;
 /// scales from 16px @ 1:1.5
 /// @type Value(px)
 $space-7         : $space-7;
 /// scales from 16px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $space-8         : $space-8;
 
@@ -88,15 +88,15 @@ $space-8         : $space-8;
 /// @type Value(px)
 $space-and-half  : $space-1*1.5;
 /// scales from 16px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $space-double    : $space-double;
 /// scales from 16px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $space-half      : $space-half;
 /// scales from 16px @ 1:1.5
-/// (provided by swarm-constants)
+/// (provided by [swarm-constants](https://meetup.github.io/swarm-constants/#layout))
 /// @type Value(px)
 $space-quarter   : $space-1/4;
 


### PR DESCRIPTION
Instead of just saying a variable is generated by `swarm-constants` in the docs, now we're actually linking to the `swarm-constants` docs.