### PR TITLE
Fix font size modifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"grunt-gh-pages": "0.9.1",
 		"grunt-preprocess": "5.1.0",
 		"grunt-sassdoc": "2.0.2",
-		"meetup-web-components": "^5.0.2339",
+		"meetup-web-components": "^5.0.2373",
 		"mwp-config": "16.0.2422",
 		"node-sass": "4.5.3",
 		"sass-loader": "6.0.1",

--- a/scss/reset/_bodyText.scss
+++ b/scss/reset/_bodyText.scss
@@ -24,7 +24,7 @@ body {
 	-o-font-feature-settings: "liga", "kern";
 	-webkit-font-feature-settings: "liga", "kern";
 	font-feature-settings: "liga", "kern";
-	font-size: rem($font-size);
+	font-size: $font-size;
 	font-weight: $W_normal;
 	line-height: $line-height;
 	text-rendering: optimizeLegibility; // stylelint-disable-line property-blacklist

--- a/scss/reset/_forms.scss
+++ b/scss/reset/_forms.scss
@@ -65,7 +65,7 @@ see <a class="link" style="text-decoration: underline;" href="https://github.com
 /* stylelint-disable selector-no-qualifying-type, selector-no-vendor-prefix */
 %label,
 label {
-	font-size: rem($font-size);
+	font-size: $font-size;
 	font-weight: $W_medium;
 }
 

--- a/scss/reset/_headings.scss
+++ b/scss/reset/_headings.scss
@@ -36,7 +36,7 @@ h3,
 h4,
 h5,
 h6 {
-	font-size: rem($font-size);
+	font-size: $font-size;
 	margin: 0;
 	padding: 0;
 }
@@ -44,7 +44,7 @@ h6 {
 h1 {
 	.view-head & {
 		@extend %text--heavy;
-		font-size: rem($font-size);
+		font-size: $font-size;
 	}
 }
 

--- a/scss/reset/_tables.scss
+++ b/scss/reset/_tables.scss
@@ -197,7 +197,7 @@ category: Tables
 	th {
 		border-width: 0;
 		color: $C_textPrimary;
-		font-size: rem($font-size);
+		font-size: $font-size;
 		font-weight: $W_normal;
 		padding: 0;
 		vertical-align: top;

--- a/scss/utils/helpers/_type.scss
+++ b/scss/utils/helpers/_type.scss
@@ -23,34 +23,34 @@
 
 /// Page title text placeholder
 %text--pageTitle {
-	font-size: rem($font-size-title);
+	font-size: $font-size-title;
 }
 
 /// Section title text placeholder
 %text--sectionTitle {
-	font-size: rem($font-size-big2);
+	font-size: $font-size-big2;
 	line-height: $line-height;
 }
 
 /// Top level display text placeholder
 %text--display1 {
-	font-size: rem($font-size-display1);
+	font-size: $font-size-display1;
 }
 
 /// Secondary level display text placeholder
 %text--display2 {
-	font-size: rem($font-size-display2);
+	font-size: $font-size-display2;
 }
 
 /// Tertiary level display text placeholder
 %text--display3 {
-	font-size: rem($font-size-display3);
+	font-size: $font-size-display3;
 }
 
 // Primary label text
 %text--label {
 	@include color-all($C_textPrimary);
-	font-size: rem($font-size-small);
+	font-size: $font-size-small;
 	font-weight: $W_bold;
 	line-height: $line-height-smallText;
 	letter-spacing: -0.02em;
@@ -113,19 +113,19 @@
 
 /// Big text
 %text--big {
-	font-size: rem($font-size-big);
+	font-size: $font-size-big;
 	line-height: $line-height-largeText;
 }
 
 /// Small text
 %text--small {
-	font-size: rem($font-size-small);
+	font-size: $font-size-small;
 	line-height: $line-height-smallText;
 }
 
 /// Tiny text
 %text--tiny {
-	font-size: rem($font-size-tiny);
+	font-size: $font-size-tiny;
 	line-height: $line-height-smallText;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,10 +1103,6 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bourbon@4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/bourbon/-/bourbon-4.2.3.tgz#d6061c90c0e28737c1a0d015672d72be9770fff0"
-
 boxen@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.2.1.tgz#0f11e7fe344edb9397977fc13ede7f64d956481d"
@@ -4417,12 +4413,11 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
-meetup-web-components@^5.0.2339:
-  version "5.0.2339"
-  resolved "https://registry.yarnpkg.com/meetup-web-components/-/meetup-web-components-5.0.2339.tgz#258cca96d21420c37eb9a28ba977916d335754b0"
+meetup-web-components@^5.0.2373:
+  version "5.0.2373"
+  resolved "https://registry.yarnpkg.com/meetup-web-components/-/meetup-web-components-5.0.2373.tgz#e168dab875300f96973461d21909537df999a46f"
   dependencies:
     autosize "3.0.21"
-    bourbon "4.2.3"
     downshift "1.31.12"
     file-loader "1.1.11"
     focus-trap-react "3.1.2"


### PR DESCRIPTION
Bourbon `rem` function was still being used, and it only worked in here because a previous version of MWC had Bourbon as a dependency