### PR TITLE
add font-display: swap for FOUT

### DIFF
--- a/scss/reset/_bodyText.scss
+++ b/scss/reset/_bodyText.scss
@@ -18,6 +18,7 @@ html {
 body {
 	color: $C_textPrimary;
 	font-family: $font;
+	font-display: swap; // allow Flash of Unstyled Text for accessibility
 	-moz-font-feature-settings: "liga", "kern";
 	-moz-font-feature-settings: "liga=1, kern=1";
 	-ms-font-feature-settings: "liga", "kern";


### PR DESCRIPTION
Part 1 of improving font loading performance - allow flash of unstyled (built-in font) text while Graphik loads on slower connections